### PR TITLE
add dependabot for weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "maven" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
- should we add the dependabot to update the matsim version every week
- because this repo will be developed and used for the next years this could be helpful to always use the latest functionalities for the main branch.

@simei94: If you have another opinion, feel free to reject it, and I will not be disappointed :) 